### PR TITLE
Revert "Fix Xcode header search paths"

### DIFF
--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -157,9 +157,6 @@ extension XcodeModule {
         // prevents Xcode project upgrade warnings
         buildSettings["COMBINE_HIDPI_IMAGES"] = "YES"
 
-        //FIXME xcode can't find local headers from modulemap
-        buildSettings["USER_HEADER_SEARCH_PATHS"] = "'$(SRCROOT)/Packages/**'"
-
         if self is TestModule {
             buildSettings["EMBEDDED_CONTENT_CONTAINS_SWIFT"] = "YES"
 


### PR DESCRIPTION
Reverts goloveychuk/swift-package-manager#1
Doesn't work with many clibs deps. Conflicts